### PR TITLE
Lua SLAM replacement

### DIFF
--- a/entities/entities/npc_tripmine_horde/cl_init.lua
+++ b/entities/entities/npc_tripmine_horde/cl_init.lua
@@ -1,4 +1,5 @@
 include("shared.lua")
+killicon.AddAlias("npc_tripmine_horde", "npc_tripmine")
 
 local lmat = Material("trails/laser")
 local color_armed, color_enemy = Color(0, 200, 200), Color(255, 0, 0)

--- a/entities/entities/npc_tripmine_horde/cl_init.lua
+++ b/entities/entities/npc_tripmine_horde/cl_init.lua
@@ -1,0 +1,17 @@
+include("shared.lua")
+
+local lmat = Material("trails/laser")
+local color_armed, color_enemy = Color(0, 200, 200), Color(255, 0, 0)
+function ENT:Draw()
+	self:DrawModel()
+end
+
+function ENT:DrawLaser()
+	if not self.Armed or not self.TraceEnd then return end
+	render.SetMaterial(lmat)
+	if self:GetTriggered() then
+		render.DrawBeam(self.TraceStart, self.TraceEnd, 7, 1, 1, color_enemy)
+	else
+		render.DrawBeam(self.TraceStart, self.TraceEnd, 7, 1, 1, color_armed)
+	end
+end

--- a/entities/entities/npc_tripmine_horde/cl_init.lua
+++ b/entities/entities/npc_tripmine_horde/cl_init.lua
@@ -3,16 +3,13 @@ killicon.AddAlias("npc_tripmine_horde", "npc_tripmine")
 
 local lmat = Material("trails/laser")
 local color_armed, color_enemy = Color(0, 200, 200), Color(255, 0, 0)
-function ENT:Draw()
-	self:DrawModel()
-end
 
 function ENT:DrawLaser()
-	if not self.Armed or not self.TraceEnd then return end
-	render.SetMaterial(lmat)
-	if self:GetTriggered() then
-		render.DrawBeam(self.TraceStart, self.TraceEnd, 7, 1, 1, color_enemy)
-	else
-		render.DrawBeam(self.TraceStart, self.TraceEnd, 7, 1, 1, color_armed)
-	end
+    if not self.Armed or not self.TraceEnd then return end
+    render.SetMaterial(lmat)
+    if self:GetTriggered() then
+        render.DrawBeam(self.TraceStart, self.TraceEnd, 7, 1, 1, color_enemy)
+    else
+        render.DrawBeam(self.TraceStart, self.TraceEnd, 7, 1, 1, color_armed)
+    end
 end

--- a/entities/entities/npc_tripmine_horde/init.lua
+++ b/entities/entities/npc_tripmine_horde/init.lua
@@ -1,0 +1,77 @@
+AddCSLuaFile("cl_init.lua")
+include("shared.lua")
+
+ENT.Damage = 200
+ENT.Radius = 200
+
+function ENT:Detonate()
+	local eff = EffectData()
+    eff:SetStart(self:GetPos())
+    eff:SetOrigin(self:GetPos())
+    util.Effect("Explosion", eff)
+
+	util.BlastDamage(self, self:GetHordeOwner(), self:GetPos(), self.Radius, self.Damage)
+	self:Remove()
+end
+
+local snd = Sound("npc/roller/mine/rmine_predetonate.wav")
+function ENT:Trigger()
+	self:SetTriggered(true)
+	self:EmitSound(snd)
+	timer.Simple(1, function()
+		if IsValid(self) then self:Detonate() end
+	end)
+end
+
+function ENT:OnTakeDamage(dmginfo)
+	if not self.Armed then return end
+	local attacker, inflictor = dmginfo:GetAttacker(), dmginfo:GetInflictor()
+
+	if not IsValid(inflictor) or inflictor == self then return end
+
+	local owner = self:GetHordeOwner()
+	if not IsValid(owner) then
+		self:Detonate()
+		return
+	end
+
+	if IsValid(attacker) and (attacker:IsNPC() or attacker == owner) then
+		self:Detonate()
+	end
+end
+
+hook.Add("OnEntityCreated", "Horde_TripMineReplacement", function(ent)
+	if ent:GetClass() == "npc_tripmine" then
+		timer.Simple(0, function()
+			if not IsValid(ent) then return end
+			local owner = ent:GetInternalVariable("m_hOwner")
+			local ent2 = ents.Create("npc_tripmine_horde")
+			ent2:SetPos(ent:GetPos())
+			ent2:SetAngles(ent:GetAngles())
+			ent:Remove()
+			--ent2:SetOwner(owner)
+			--ent2:SetHordeOwner(owner)
+			ent2.HordeOwner = owner
+			ent2:Spawn()
+		end)
+	end
+end)
+
+local reuse = CreateConVar("horde_tripmine_reusable", 1, FCVAR_SERVER_CAN_EXECUTE, "Can tripwire mines(SLAM's) be picked up after being armed?")
+function ENT:Use(ply)
+	local owner = self:GetHordeOwner()
+	if reuse:GetBool() == false then return end
+	if self:GetTriggered() then return end
+	if IsValid(owner) and owner != ply then return end	-- feel free to steal disconnected player mines
+
+	-- I don't want player to be able to difuse mines with wrong class >:c
+	-- btw, saboteur class when?
+	local item = HORDE.items[self.SWEP]
+	if not item or ply:GetHordeWeight() - item.weight < 0 or not item.whitelist[ply:GetHordeClass().name] then return end
+
+	self:Remove()
+	ply:GiveAmmo(1, "slam")
+	if not IsValid(ply:GetWeapon(self.SWEP)) then
+		ply:Give(self.SWEP, true)
+	end
+end

--- a/entities/entities/npc_tripmine_horde/init.lua
+++ b/entities/entities/npc_tripmine_horde/init.lua
@@ -5,12 +5,14 @@ ENT.Damage = 200
 ENT.Radius = 200
 
 function ENT:Detonate()
+	self.Detonated = true
+	local pos = self:GetPos()
 	local eff = EffectData()
-    eff:SetStart(self:GetPos())
-    eff:SetOrigin(self:GetPos())
+    eff:SetStart(pos)
+    eff:SetOrigin(pos)
     util.Effect("Explosion", eff)
 
-	util.BlastDamage(self, self:GetHordeOwner(), self:GetPos(), self.Radius, self.Damage)
+	util.BlastDamage(self, self:GetHordeOwner(), pos, self.Radius, self.Damage)
 	self:Remove()
 end
 
@@ -24,7 +26,7 @@ function ENT:Trigger()
 end
 
 function ENT:OnTakeDamage(dmginfo)
-	if not self.Armed then return end
+	if not self.Armed or self.Detonated then return end
 	local attacker, inflictor = dmginfo:GetAttacker(), dmginfo:GetInflictor()
 
 	if not IsValid(inflictor) or inflictor == self then return end
@@ -35,7 +37,7 @@ function ENT:OnTakeDamage(dmginfo)
 		return
 	end
 
-	if IsValid(attacker) and (attacker:IsNPC() or attacker == owner) then
+	if IsValid(attacker) and (attacker:IsNPC() and not IsValid(attacker:GetNWEntity("HordeOwner")) or attacker == owner) then
 		self:Detonate()
 	end
 end

--- a/entities/entities/npc_tripmine_horde/init.lua
+++ b/entities/entities/npc_tripmine_horde/init.lua
@@ -1,82 +1,83 @@
 AddCSLuaFile("cl_init.lua")
 include("shared.lua")
 
+local reuse = CreateConVar("horde_tripmine_reusable", 1, FCVAR_SERVER_CAN_EXECUTE, "Can tripwire mines(SLAM's) be picked up after being armed?")
+
 ENT.SWEP = "weapon_slam"
-ENT.Damage = 200
-ENT.Radius = 200
+ENT.Damage = 350
+ENT.Radius = 220
 
 function ENT:Detonate()
-	self.Detonated = true
-	local pos = self:GetPos()
-	local eff = EffectData()
+    self.Detonated = true
+    local pos = self:GetPos()
+    local eff = EffectData()
     eff:SetStart(pos)
     eff:SetOrigin(pos)
     util.Effect("Explosion", eff)
 
-	util.BlastDamage(self, self:GetHordeOwner(), pos, self.Radius, self.Damage)
-	self:Remove()
+    util.BlastDamage(self, self:GetHordeOwner(), pos, self.Radius, self.Damage)
+    self:Remove()
 end
 
 local snd = Sound("npc/roller/mine/rmine_predetonate.wav")
 function ENT:Trigger()
-	self:SetTriggered(true)
-	self:EmitSound(snd, 65)
-	timer.Simple(1, function()
-		if IsValid(self) then self:Detonate() end
-	end)
+    self:SetTriggered(true)
+    self:EmitSound(snd, 65)
+    timer.Simple(1, function()
+        if IsValid(self) then self:Detonate() end
+    end)
 end
 
 function ENT:OnTakeDamage(dmginfo)
-	if not self.Armed or self.Detonated then return end
-	local attacker, inflictor = dmginfo:GetAttacker(), dmginfo:GetInflictor()
+    if not self.Armed or self.Detonated then return end
+    local attacker, inflictor = dmginfo:GetAttacker(), dmginfo:GetInflictor()
 
-	if not IsValid(inflictor) or inflictor == self then return end
+    if not IsValid(inflictor) or inflictor == self then return end
 
-	local owner = self:GetHordeOwner()
-	if not IsValid(owner) then
-		self:Detonate()
-		return
-	end
+    local owner = self:GetHordeOwner()
+    if not IsValid(owner) then
+        self:Detonate()
+        return
+    end
 
-	if IsValid(attacker) and (attacker:IsNPC() and not IsValid(attacker:GetNWEntity("HordeOwner")) or attacker == owner) then
-		self:Detonate()
-	end
+    if IsValid(attacker) and (attacker:IsNPC() and not IsValid(attacker:GetNWEntity("HordeOwner")) or attacker == owner) then
+        self:Detonate()
+    end
 end
 
 hook.Add("OnEntityCreated", "Horde_TripMineReplacement", function(ent)
-	if ent:GetClass() == "npc_tripmine" then
-		timer.Simple(0, function()
-			if not IsValid(ent) then return end
-			local owner = ent:GetInternalVariable("m_hOwner")
-			local ent2 = ents.Create("npc_tripmine_horde")
-			ent2:SetPos(ent:GetPos())
-			ent2:SetAngles(ent:GetAngles())
-			ent:Remove()
-			--ent2:SetOwner(owner)
-			--ent2:SetHordeOwner(owner)
-			ent2.HordeOwner = owner
-			ent2:Spawn()
-		end)
-	end
+    if ent:GetClass() == "npc_tripmine" then
+        timer.Simple(0, function()
+            if not IsValid(ent) then return end
+            local owner = ent:GetInternalVariable("m_hOwner")
+            local ent2 = ents.Create("npc_tripmine_horde")
+            ent2:SetPos(ent:GetPos())
+            ent2:SetAngles(ent:GetAngles())
+            ent:Remove()
+            --ent2:SetOwner(owner)
+            --ent2:SetHordeOwner(owner)
+            ent2.HordeOwner = owner
+            ent2:Spawn()
+        end)
+    end
 end)
 
-local reuse = CreateConVar("horde_tripmine_reusable", 1, FCVAR_SERVER_CAN_EXECUTE, "Can tripwire mines(SLAM's) be picked up after being armed?")
-local defuse = Sound("weapons/c4/c4_disarm.wav")
+local defuse = Sound("ambient/machines/pneumatic_drill_3.wav")
 function ENT:Use(ply)
-	local owner = self:GetHordeOwner()
-	if reuse:GetBool() == false then return end
-	if self:GetTriggered() then return end
-	if IsValid(owner) and owner != ply then return end	-- feel free to steal disconnected player mines
+    local owner = self:GetHordeOwner()
+    if reuse:GetBool() == false then return end
+    if self:GetTriggered() then return end
+    if IsValid(owner) and owner != ply then return end    -- feel free to steal disconnected player mines
 
-	-- I don't want player to be able to difuse mines with wrong class >:c
-	-- btw, saboteur class when?
-	local item = HORDE.items[self.SWEP]
-	if not item or ply:GetHordeWeight() - item.weight < 0 or not item.whitelist[ply:GetHordeClass().name] then return end
+    -- I don't want player to be able to difuse mines with wrong class >:c
+    -- btw, saboteur class when?
+    local item = HORDE.items[self.SWEP]
+    if not item or ply:GetHordeWeight() - item.weight < 0 or not item.whitelist[ply:GetHordeClass().name] then return end
 
-	self:EmitSound(defuse, 60)
-	self:Remove()
-	ply:GiveAmmo(1, "slam", true)
-	if not IsValid(ply:GetWeapon(self.SWEP)) then
-		ply:Give(self.SWEP, true)
-	end
+    self:EmitSound(defuse, 60)
+    self:Remove()
+    ply:GiveAmmo(1, "slam", true)
+    if not IsValid(ply:GetWeapon(self.SWEP)) then
+        ply:Give(self.SWEP, true)
+    end
 end

--- a/entities/entities/npc_tripmine_horde/init.lua
+++ b/entities/entities/npc_tripmine_horde/init.lua
@@ -1,6 +1,7 @@
 AddCSLuaFile("cl_init.lua")
 include("shared.lua")
 
+ENT.SWEP = "weapon_slam"
 ENT.Damage = 200
 ENT.Radius = 200
 
@@ -19,7 +20,7 @@ end
 local snd = Sound("npc/roller/mine/rmine_predetonate.wav")
 function ENT:Trigger()
 	self:SetTriggered(true)
-	self:EmitSound(snd)
+	self:EmitSound(snd, 65)
 	timer.Simple(1, function()
 		if IsValid(self) then self:Detonate() end
 	end)
@@ -60,6 +61,7 @@ hook.Add("OnEntityCreated", "Horde_TripMineReplacement", function(ent)
 end)
 
 local reuse = CreateConVar("horde_tripmine_reusable", 1, FCVAR_SERVER_CAN_EXECUTE, "Can tripwire mines(SLAM's) be picked up after being armed?")
+local defuse = Sound("weapons/c4/c4_disarm.wav")
 function ENT:Use(ply)
 	local owner = self:GetHordeOwner()
 	if reuse:GetBool() == false then return end
@@ -71,8 +73,9 @@ function ENT:Use(ply)
 	local item = HORDE.items[self.SWEP]
 	if not item or ply:GetHordeWeight() - item.weight < 0 or not item.whitelist[ply:GetHordeClass().name] then return end
 
+	self:EmitSound(defuse, 60)
 	self:Remove()
-	ply:GiveAmmo(1, "slam")
+	ply:GiveAmmo(1, "slam", true)
 	if not IsValid(ply:GetWeapon(self.SWEP)) then
 		ply:Give(self.SWEP, true)
 	end

--- a/entities/entities/npc_tripmine_horde/shared.lua
+++ b/entities/entities/npc_tripmine_horde/shared.lua
@@ -1,0 +1,51 @@
+AddCSLuaFile()
+
+ENT.Type = "anim"
+ENT.SWEP = "weapon_slam"
+
+function ENT:Initialize()
+	timer.Simple(2, function()
+		if IsValid(self) then self:Arm() end
+	end)
+	if CLIENT then
+		hook.Add("PostDrawTranslucentRenderables", self, self.DrawLaser)
+		return
+	end
+
+	self:SetModel("models/weapons/w_slam.mdl")
+	self:PhysicsInit(SOLID_VPHYSICS)
+	self:SetMoveType(MOVETYPE_NONE)
+	self:SetCollisionGroup(COLLISION_GROUP_WORLD)
+	self:SetUseType(SIMPLE_USE)
+	self:SetBodygroup(0, 1)
+end
+
+function ENT:SetupDataTables()
+	self:NetworkVar("Bool", 0, "Triggered")	-- sadly desyncs sometimes without that
+	--self:NetworkVar("Entity", 0, "HordeOwner")	-- cuz NWEntity "HordeOwner" blocks all incoming damage from owner >:c
+end
+
+function ENT:GetHordeOwner()	-- Actually this shouldn't be networked anyway
+	return self.HordeOwner
+end
+
+function ENT:Arm()
+	self.TraceStart = self:GetAttachment(self:LookupAttachment("beam_attach")).Pos
+	self.TraceData = {start = self.TraceStart, endpos = self.TraceStart + self:GetUp()*200}
+	self.Armed = true
+end
+
+function ENT:Think()
+	if not self.Armed or self:GetTriggered() then return end
+	self.TraceData.filter = player.GetAll()
+	local tr = util.TraceLine(self.TraceData)
+	self.TraceEnd = tr.HitPos
+	if SERVER then
+		local ent = tr.Entity
+		if IsValid(ent) and ent:IsNPC() and not IsValid(ent:GetNWEntity("HordeOwner")) then
+			self:Trigger()
+		end
+	end
+	self:NextThink(CurTime()+0.1)
+	return true
+end

--- a/entities/entities/npc_tripmine_horde/shared.lua
+++ b/entities/entities/npc_tripmine_horde/shared.lua
@@ -1,7 +1,6 @@
 AddCSLuaFile()
 
 ENT.Type = "anim"
-ENT.SWEP = "weapon_slam"
 
 function ENT:Initialize()
 	timer.Simple(2, function()

--- a/entities/entities/npc_tripmine_horde/shared.lua
+++ b/entities/entities/npc_tripmine_horde/shared.lua
@@ -3,48 +3,48 @@ AddCSLuaFile()
 ENT.Type = "anim"
 
 function ENT:Initialize()
-	timer.Simple(2, function()
-		if IsValid(self) then self:Arm() end
-	end)
-	if CLIENT then
-		hook.Add("PostDrawTranslucentRenderables", self, self.DrawLaser)
-		return
-	end
+    timer.Simple(2, function()
+        if IsValid(self) then self:Arm() end
+    end)
+    if CLIENT then
+        hook.Add("PostDrawTranslucentRenderables", self, self.DrawLaser)
+        return
+    end
 
-	self:SetModel("models/weapons/w_slam.mdl")
-	self:PhysicsInit(SOLID_VPHYSICS)
-	self:SetMoveType(MOVETYPE_NONE)
-	self:SetCollisionGroup(COLLISION_GROUP_WORLD)
-	self:SetUseType(SIMPLE_USE)
-	self:SetBodygroup(0, 1)
+    self:SetModel("models/weapons/w_slam.mdl")
+    self:PhysicsInit(SOLID_VPHYSICS)
+    self:SetMoveType(MOVETYPE_NONE)
+    self:SetCollisionGroup(COLLISION_GROUP_WORLD)
+    self:SetUseType(SIMPLE_USE)
+    self:SetBodygroup(0, 1)
 end
 
 function ENT:SetupDataTables()
-	self:NetworkVar("Bool", 0, "Triggered")	-- sadly desyncs sometimes without that
-	--self:NetworkVar("Entity", 0, "HordeOwner")	-- cuz NWEntity "HordeOwner" blocks all incoming damage from owner >:c
+    self:NetworkVar("Bool", 0, "Triggered")    -- sadly desyncs sometimes without that
+    --self:NetworkVar("Entity", 0, "HordeOwner")    -- cuz NWEntity "HordeOwner" blocks all incoming damage from owner >:c
 end
 
-function ENT:GetHordeOwner()	-- Actually this shouldn't be networked anyway
-	return self.HordeOwner
+function ENT:GetHordeOwner()    -- Actually this shouldn't be networked anyway
+    return self.HordeOwner
 end
 
 function ENT:Arm()
-	self.TraceStart = self:GetAttachment(self:LookupAttachment("beam_attach")).Pos
-	self.TraceData = {start = self.TraceStart, endpos = self.TraceStart + self:GetUp()*200}
-	self.Armed = true
+    self.TraceStart = self:GetAttachment(self:LookupAttachment("beam_attach")).Pos
+    self.TraceData = {start = self.TraceStart, endpos = self.TraceStart + self:GetUp()*200}
+    self.Armed = true
 end
 
 function ENT:Think()
-	if not self.Armed or self:GetTriggered() then return end
-	self.TraceData.filter = player.GetAll()
-	local tr = util.TraceLine(self.TraceData)
-	self.TraceEnd = tr.HitPos
-	if SERVER then
-		local ent = tr.Entity
-		if IsValid(ent) and ent:IsNPC() and not IsValid(ent:GetNWEntity("HordeOwner")) then
-			self:Trigger()
-		end
-	end
-	self:NextThink(CurTime()+0.1)
-	return true
+    if not self.Armed or self:GetTriggered() then return end
+    self.TraceData.filter = player.GetAll()
+    local tr = util.TraceLine(self.TraceData)
+    self.TraceEnd = tr.HitPos
+    if SERVER then
+        local ent = tr.Entity
+        if IsValid(ent) and ent:IsNPC() and not IsValid(ent:GetNWEntity("HordeOwner")) then
+            self:Trigger()
+        end
+    end
+    self:NextThink(CurTime()+0.1)
+    return true
 end


### PR DESCRIPTION
No one asked for that, no one even bothers using SLAM's cuz it's one of the most useless weapons in Horde currently, but I did it ʕ•ᴥ•ʔ
On a bit more serious note, this replaces built-in npc_tripmine upon placement with a bit more PvE oriented counterpart.
Only owner(or NPC's) can detonate it by dealing damage, also it's getting triggered only by not player-owned NPC's. Damage/Explosion radius is configurable to be further balanced. Laser length is limited, because no one needs lasers that cross whole map. It also can be defused(ConVar horde_tripmine_reusable) by owner(or by anyone if owner disconnected), if it has correct class, by pressing +use on it.
P.S.I wonder how much zombies I could've killed today instead of spending so much time on researching useless SLAM mechanics...