### PR TITLE
Armor no longer hardcoded, better PlayerUse hook

### DIFF
--- a/gamemode/sh_item.lua
+++ b/gamemode/sh_item.lua
@@ -4,6 +4,7 @@ HORDE.items = {}
 HORDE.ENTITY_PROPERTY_WPN = 1
 HORDE.ENTITY_PROPERTY_GIVE = 2
 HORDE.ENTITY_PROPERTY_DROP = 3
+HORDE.ENTITY_PROPERTY_ARMOR = 4
 
 HORDE.categories = {"Melee", "Pistol", "SMG", "Shotgun", "Rifle", "MG", "Explosive", "Special", "Equipment", "Attachment"}
 HORDE.entity_categories = {"Special", "Equipment"}
@@ -220,19 +221,19 @@ HORDE.GetDefaultItemsData = function()
     {Medic=true, Assault=true, Heavy=true, Demolition=true, Survivor=true, Ghost=true, Engineer=true}, 10, -1)
     HORDE.CreateItem("Equipment",  "Health Vial",    "item_healthvial",    20,   1, "A capsule filled with sticky green liquid.\nHeals instantly when picked up.",
     {Medic=true, Assault=false, Heavy=false, Demolition=false, Survivor=false, Ghost=false, Engineer=false}, 10, -1, {type=HORDE.ENTITY_PROPERTY_DROP, x=50, z=15, yaw=0, limit=5})
-    
+    HORDE.CreateItem("Equipment", "Kevlar Armor", "armor100", 1000, 0, "Full kevlar armor set.\nFills up 100% of your armor bar.",
+    {Medic=true, Assault=true, Heavy=true, Demolition=true, Survivor=true, Ghost=true, Engineer=true}, 10, -1, {type=HORDE.ENTITY_PROPERTY_ARMOR, armor=100})
+    --[[
+    HORDE.CreateItem("Equipment", "Kaom's Heart", "armor_glorious_plate", 10000, 0, "The warrior who fears will fall.",
+    {Medic=true, Assault=true, Heavy=true, Demolition=true, Survivor=true, Ghost=true, Engineer=true}, 10, -1, {type=HORDE.ENTITY_PROPERTY_ARMOR, armor=931})
+    ]]
+
     if ArcCWInstalled == true and GetConVar("horde_arccw_attinv_free"):GetInt() == 0 then
         print("[HORDE] ArcCW detected. Loading attachments into shop.")
         HORDE.GetArcCWAttachments()
     end
 
     print("[HORDE] - Loaded default item config.")
-end
-
-HORDE.GetSpecialItems = function ()
-    -- Some built-in special items
-    HORDE.CreateItem("Equipment", "Kevlar Armor", "armor", 1000, 0, "Full kevlar armor set.\nFills up 100% of your armor bar.",
-    {Medic=true, Assault=true, Heavy=true, Demolition=true, Survivor=true, Ghost=true, Engineer=true}, 10, -1)
 end
 
 HORDE.GetArcCWAttachments = function ()
@@ -595,10 +596,8 @@ if SERVER then
 
     if GetConVarNumber("horde_default_item_config") == 0 then
         GetItemsData()
-        HORDE.GetSpecialItems()
     else
         HORDE.GetDefaultItemsData()
-        HORDE.GetSpecialItems()
         HORDE.SyncItems()
     end
 

--- a/gamemode/sv_economy.lua
+++ b/gamemode/sv_economy.lua
@@ -319,6 +319,17 @@ net.Receive("Horde_BuyItem", function (len, ply)
                         if not ent:IsValid() then timer.Remove("Horde_MinionCollision" .. id) return end
                         ent:SetCollisionGroup(COLLISION_GROUP_WORLD)
                     end)
+
+                    local npc_info = list.Get("NPC")[ent:GetClass()]
+                    if not npc_info then
+                        print("[HORDE] NPC does not exist in ", list.Get("NPC"))
+                    end
+
+                    local wpns = npc_info["Weapons"]
+                    if wpns then
+                        local wpn = wpns[math.random(#wpns)]
+                        ent:Give(wpn)
+                    end
                 end
                 ent:CallOnRemove("Horde_EntityRemoved", function()
                     if ent:IsValid() and ply:IsValid() then


### PR DESCRIPTION
Previously PlayerUse was always returning true for every player-owned entity. This way it was overriding other addons possible use restrictions, which is kinda bad for custom configs.
Actually it still always returns true, but instead now it's rather default gamemode behavior that won't break other addons hooks. Let's hope these addons won't be returning true for no reason in their hooks.