### PR TITLE
Some fixes

### DIFF
--- a/entities/entities/npc_tripmine_horde/init.lua
+++ b/entities/entities/npc_tripmine_horde/init.lua
@@ -47,7 +47,7 @@ end
 
 hook.Add("OnEntityCreated", "Horde_TripMineReplacement", function(ent)
     if ent:GetClass() == "npc_tripmine" then
-        timer.Simple(0, function()
+        timer.Simple(0.5, function()
             if not IsValid(ent) then return end
             local owner = ent:GetInternalVariable("m_hOwner")
             local ent2 = ents.Create("npc_tripmine_horde")

--- a/gamemode/shared.lua
+++ b/gamemode/shared.lua
@@ -4,7 +4,7 @@ GM.Email = "N/A"
 GM.Website = "N/A"
 
 CreateConVar("horde_enable_sandbox", 0, FCVAR_SERVER_CAN_EXECUTE, "Enables sandbox/cheat features.")
-CreateConVar("horde_enable_player_collision", 1, FCVAR_SERVER_CAN_EXECUTE, "Enables player collision.")
+CreateConVar("horde_enable_player_collision", 0, {FCVAR_SERVER_CAN_EXECUTE, FCVAR_REPLICATED}, "Enables player collision.")
 
 DeriveGamemode("sandbox")
 
@@ -71,7 +71,7 @@ local nums = {"_01", "_02", "_03", "_04", "_05", "_06"}
 
 function GM:PlayerSetModel(ply) return ply:SetModel("models/player/" .. table.Random(groups) .. "/" .. table.Random(sex) .. table.Random(nums) .. ".mdl") end
 
-function GM:ShouldCollide(ent1, ent2)   
+function GM:ShouldCollide(ent1, ent2)
     -- Ulti: Yes, this does prevents bullets from colliding with teammates somehow
     if ent1:IsPlayer() or ent2:IsPlayer() then
         if GetConVar("horde_enable_player_collision"):GetInt() == 0 and ent1:IsPlayer() and ent2:IsPlayer() then return false end

--- a/gamemode/sv_economy.lua
+++ b/gamemode/sv_economy.lua
@@ -373,7 +373,7 @@ end)
 
 function GM:PlayerUse(other_ply, target)    -- This will make it to be default behaviour, that can be overridden by other addons hooks. Let's hope they won't return true >.>
     local owner = target:GetNWEntity("HordeOwner")
-    if not IsValid(owner) or other_ply ~= owner then return false end   -- If owner disconnected/not valid, why would we care about ownership?
+    if IsValid(owner) and other_ply ~= owner then return false end   -- If owner disconnected/not valid, why would we care about ownership?
 
     if target:GetClass() == "npc_turret_floor" then
         target:GetPhysicsObject():EnableMotion(true)


### PR DESCRIPTION
Fixed my mistake with GM:PlayerUse
Added FCVAR_REPLICATED flag to horde_enable_player_collision convar and made it 0 by default. For some reason now bullets won't go through with player collision enabled. Did I forgot something :thinking: 
Increased delay between replacing HL2 tripmine with modified one. Not sure why, but it wasn't working on server I'm playing .-.