### PR TITLE
Turret accuracy modification

### DIFF
--- a/gamemode/sv_economy.lua
+++ b/gamemode/sv_economy.lua
@@ -657,3 +657,28 @@ function HORDE:CanSell(ply, class)
 
     return true
 end
+
+function Player:GetMinionSpreadModifier()   -- Placeholder for perks
+    return 0.5
+end
+
+--[[
+function Player:GetMinionDamageOverride()   -- Placeholder for perks
+    return 17
+end
+]]
+--https://github.com/ValveSoftware/source-sdk-2013/blob/master/sp/src/game/server/hl2/npc_turret_floor.cpp
+local VECTOR_CONE_10DEGREES	= Vector(87.16, 87.16, 0)
+hook.Add("EntityFireBullets", "Horde_ModifyTurretBullet", function(ent, data)
+    if ent:GetClass() == "npc_turret_floor" then
+        data.TracerName = "Tracer"  -- less annoying tracer
+        local enemy, owner = ent:GetEnemy(), ent:GetNWEntity("HordeOwner")
+        if IsValid(enemy) and owner:IsPlayer() then
+            data.Dir = enemy:BodyTarget(data.Src) - data.Src
+            data.Spread = VECTOR_CONE_10DEGREES * owner:GetMinionSpreadModifier()
+            data.IgnoreEntity = owner   -- Well, why not?
+            --data.Damage = owner:GetMinionDamageOverride() -- Btw you can override bullet damage here too instead of modifying CTakeDamageInfo
+        end
+        return true
+    end
+end)


### PR DESCRIPTION
Spent some time on testing and found out a way to modify bullet spread of turrets \o/
Also swapped AR2 Tracer to normal bullet one, because it looks pretty messy when a lot of turrets are shooting simultaneously.
VECTOR_CONE_10DEGREES value is default(or close to?) turret spread.
Also turret bullets now ignore turret owner.