### PR TITLE
Fix for Skull Token not syncing economy

### DIFF
--- a/entities/entities/horde_skull_token/init.lua
+++ b/entities/entities/horde_skull_token/init.lua
@@ -38,6 +38,7 @@ end
 function ENT:StartTouch(ent)
     if ent:IsPlayer() then
         ent:Horde_AddSkullTokens(1)
+		ent:Horde_SyncEconomy()
         sound.Play("items/battery_pickup.wav", self:GetPos())
         self:Remove()
     end


### PR DESCRIPTION
Skull Token does not use `Horde_SyncEconomy()` when being picked up, leading to a slight annoyance that your skull token count isn't properly displayed when you pick it up. This fixes it by immediately syncing the economy upon being picked up, allowing you to see the change.