### PR TITLE
Add give money command for debug purposes

### DIFF
--- a/gamemode/sv_commands.lua
+++ b/gamemode/sv_commands.lua
@@ -348,26 +348,15 @@ concommand.Add("horde_testing_give_money", function (ply, cmd, args)
         net.Send(ply)
         return
     end
-    local amount = math.floor(tonumber(args[1]))
-    ply:Horde_AddMoney(amount)
-    ply:Horde_SyncEconomy()
-end)
-
-concommand.Add("horde_testing_take_money", function (ply, cmd, args)
-    if GetConVar("horde_enable_sandbox"):GetInt() == 0 then
-        net.Start("Horde_LegacyNotification")
-            net.WriteString("Command only available in sandbox mode.")
-            net.WriteInt(1,2)
-        net.Send(ply)
-        return
-    end
-    local amount = math.floor(tonumber(args[1]))
-	if amount >= ply:Horde_GetMoney() then 
+	
+	local amount = math.floor(tonumber(args[1]))
+	
+if (ply:Horde_GetMoney() + amount) < 0 then 
 	ply:Horde_AddMoney(-(ply:Horde_GetMoney()))
 	ply:Horde_SyncEconomy()
-	return 
-	end
-    ply:Horde_AddMoney(-amount)
+	return end
+
+    ply:Horde_AddMoney(amount)
     ply:Horde_SyncEconomy()
 end)
 

--- a/gamemode/sv_commands.lua
+++ b/gamemode/sv_commands.lua
@@ -332,9 +332,7 @@ concommand.Add("horde_testing_gorlami", function (ply, cmd, args)
     if ply:IsAdmin() then
         RunConsoleCommand("horde_testing_free_perks", 0)
         local amount = 500
-		local money = 100000
         ply:Horde_AddSkullTokens(amount)
-		ply:Horde_AddMoney(money)
         ply:Horde_SyncEconomy()
         RunConsoleCommand("horde_testing_disable_level_restrictions")
     end

--- a/gamemode/sv_commands.lua
+++ b/gamemode/sv_commands.lua
@@ -332,10 +332,25 @@ concommand.Add("horde_testing_gorlami", function (ply, cmd, args)
     if ply:IsAdmin() then
         RunConsoleCommand("horde_testing_free_perks", 0)
         local amount = 500
+		local money = 100000
         ply:Horde_AddSkullTokens(amount)
+		ply:Horde_AddMoney(money)
         ply:Horde_SyncEconomy()
         RunConsoleCommand("horde_testing_disable_level_restrictions")
     end
+end)
+
+concommand.Add("horde_testing_give_money", function (ply, cmd, args)
+    if GetConVar("horde_enable_sandbox"):GetInt() == 0 then
+        net.Start("Horde_LegacyNotification")
+            net.WriteString("Command only available in sandbox mode.")
+            net.WriteInt(1,2)
+        net.Send(ply)
+        return
+    end
+    local amount = math.floor(tonumber(args[1]))
+    ply:Horde_AddMoney(amount)
+    ply:Horde_SyncEconomy()
 end)
 
 concommand.Add("horde_testing_free_perks", function (ply, cmd, args)

--- a/gamemode/sv_commands.lua
+++ b/gamemode/sv_commands.lua
@@ -353,6 +353,26 @@ concommand.Add("horde_testing_give_money", function (ply, cmd, args)
     ply:Horde_SyncEconomy()
 end)
 
+concommand.Add("horde_testing_take_money", function (ply, cmd, args)
+    if GetConVar("horde_enable_sandbox"):GetInt() == 0 then
+        net.Start("Horde_LegacyNotification")
+            net.WriteString("Command only available in sandbox mode.")
+            net.WriteInt(1,2)
+        net.Send(ply)
+        return
+    end
+    local amount = math.floor(tonumber(args[1]))
+	if amount > ply:Horde_GetMoney() then 
+	net.Start("Horde_LegacyNotification")
+            net.WriteString("Amount to be taken exceeds current cash!")
+            net.WriteInt(1,2)
+        net.Send(ply)
+	return 
+	end
+    ply:Horde_AddMoney(-amount)
+    ply:Horde_SyncEconomy()
+end)
+
 concommand.Add("horde_testing_free_perks", function (ply, cmd, args)
     if GetConVar("horde_enable_sandbox"):GetInt() == 0 then
         net.Start("Horde_LegacyNotification")

--- a/gamemode/sv_commands.lua
+++ b/gamemode/sv_commands.lua
@@ -362,11 +362,9 @@ concommand.Add("horde_testing_take_money", function (ply, cmd, args)
         return
     end
     local amount = math.floor(tonumber(args[1]))
-	if amount > ply:Horde_GetMoney() then 
-	net.Start("Horde_LegacyNotification")
-            net.WriteString("Amount to be taken exceeds current cash!")
-            net.WriteInt(1,2)
-        net.Send(ply)
+	if amount >= ply:Horde_GetMoney() then 
+	ply:Horde_AddMoney(-(ply:Horde_GetMoney()))
+	ply:Horde_SyncEconomy()
 	return 
 	end
     ply:Horde_AddMoney(-amount)


### PR DESCRIPTION
Currently, there are not any sandbox commands for changing money directly. With these commands, these can help sandbox users / addon creators to change money values without the need to leave the game to edit their money values.