### PR TITLE
Fix for Grudge to cap minimum value

### DIFF
--- a/gamemode/perks/psycho/psycho_grudge.lua
+++ b/gamemode/perks/psycho/psycho_grudge.lua
@@ -14,13 +14,13 @@ PERK.Hooks = {}
 
 PERK.Hooks.Horde_OnPlayerCriticalCheck = function (ply, npc, bonus, hitgroup, dmginfo, crit_bonus)
     if ply:Horde_GetPerk("psycho_grudge") then
-        crit_bonus.increase = crit_bonus.increase + 0.01 * (1 - ply:Health() / ply:GetMaxHealth())
+        crit_bonus.increase = crit_bonus.increase + 0.01 * (math.max(0, 1 - ply:Health() / ply:GetMaxHealth()))
     end
 end
 
 PERK.Hooks.Horde_PlayerMoveBonus = function (ply, bonus_walk, bonus_run)
     if ply:Horde_GetPerk("psycho_grudge") then
-        local increase = math.min(0.5, (0.01 * (1 - ply:Health() / ply:GetMaxHealth())))
+        local increase = math.min(0.5, math.max(0, (0.01 * (1 - ply:Health() / ply:GetMaxHealth()))))
         bonus_walk.increase = bonus_walk.increase + increase
         bonus_run.increase = bonus_run.increase + increase
     end


### PR DESCRIPTION
Currently, Grudge contains an oversight where if your current health exceeds your max health (e.g. you have overhealth), you will actually lose crit chance and move speed. Since vanilla Horde doesn't give you much of an ability to allow you to achieve an absurd amount, this normally isn't much of an issue due to it outputting miniscule amounts such as -0.002. With this fix, the minimum value is capped at 0, meaning that you will no longer be able to lose any stats.