### PR TITLE
Added convar to disable battery drop on non-default item configs

### DIFF
--- a/gamemode/sh_horde.lua
+++ b/gamemode/sh_horde.lua
@@ -37,6 +37,7 @@ CreateConVar("horde_total_enemies_scaling", 0, FCVAR_SERVER_CAN_EXECUTE, "Forces
 CreateConVar("horde_perk_start_wave", 1, FCVAR_SERVER_CAN_EXECUTE + FCVAR_REPLICATED, "The wave when Tier 1 perks are active.")
 CreateConVar("horde_perk_scaling", 2, FCVAR_SERVER_CAN_EXECUTE + FCVAR_REPLICATED, "The multiplier to the level for which wave it is unlocked. e.g. at 1.5, perk level 4 is unlocked at start_wave + 6.", 0)
 
+CreateConVar("horde_shop_battery_drop_disabled", 1, FCVAR_ARCHIVE + FCVAR_REPLICATED, "Whether or not to allow players to drop batteries on the ground upon buying them from the shop. Enabling the default config for items will ignore this convar and always disable it.")
 CreateConVar("horde_enable_starter", 1, FCVAR_ARCHIVE + FCVAR_REPLICATED, "Enables starter weapons.")
 CreateConVar("horde_arccw_attinv_free", 1, FCVAR_SERVER_CAN_EXECUTE + FCVAR_REPLICATED, "Free ArcCW attachments.")
 

--- a/gamemode/sv_economy.lua
+++ b/gamemode/sv_economy.lua
@@ -422,6 +422,10 @@ net.Receive("Horde_BuyItem", function (len, ply)
                 -- Give entity
                 if GetConVar("horde_default_item_config"):GetInt() == 1 and class == "item_battery" then
                     -- Prevent distribution of batteries.
+                   if ply:Armor() >= ply:GetMaxArmor() then return end
+                end
+				if GetConVar("horde_shop_battery_drop_disabled"):GetInt() == 1 and class == "item_battery" then
+                    -- Prevent distribution of batteries.
                     if ply:Armor() >= ply:GetMaxArmor() then return end
                 end
                 ply:Horde_AddMoney(-price)


### PR DESCRIPTION
Horde includes a check to disable being able drop batteries on the ground whenever you buy the Kevlar Armor Battery. However, this check only works if you have the default config enabled, meaning that servers that aren't using the default config are forced to allow purchased batteries to be dropped onto the ground. With this convar, server owners will have the ability to choose whether or not this behavior will happen.