### PR TITLE
Fix for all perk choice issues

### DIFF
--- a/gamemode/gui/cl_description.lua
+++ b/gamemode/gui/cl_description.lua
@@ -156,12 +156,11 @@ function PANEL:DoClick()
         Derma_Query("Changing class will remove all your items!", "Change Class",
             "Yes",
             function()
-                MySelf:Horde_SetSubclass(self.item.name, MySelf.Horde_subclass_choices[self.item.name])
+                HORDE:SendSavedPerkChoices(MySelf.Horde_subclass_choices[self.item.name])
                 net.Start("Horde_SelectClass")
                 net.WriteString(self.item.name)
                 net.WriteString(MySelf.Horde_subclass_choices[self.item.name])
                 net.SendToServer()
-                HORDE:SendSavedPerkChoices(MySelf.Horde_subclass_choices[self.item.name])
 
                 file.Write("horde/class_choices.txt", self.item.subclass.PrintName)
             end,

--- a/gamemode/gui/cl_subclassbutton.lua
+++ b/gamemode/gui/cl_subclassbutton.lua
@@ -63,6 +63,7 @@ function PANEL:DoClick()
         Derma_Query("Change Subclass?", "Change Subclass",
                 "Yes",
                 function()
+                    HORDE:SendSavedPerkChoices(self.info.subclass.PrintName)
                     MySelf:Horde_SetSubclass(self.info.class, self.info.subclass.PrintName)
                     HORDE:ToggleShop()
                     MySelf.Horde_subclass_choices[self.info.class] = self.info.subclass.PrintName

--- a/gamemode/sh_class.lua
+++ b/gamemode/sh_class.lua
@@ -588,9 +588,10 @@ hook.Add("InitPostEntity", "Horde_PlayerInit", function()
                 class = HORDE.Class_Survivor
             end
             local f2 = file.Read("horde/class_choices.txt", "DATA")
-            if HORDE.subclasses_to_classes[f2] then
+	    -- I Seriously don't understand what it's supposed to do.
+            --[[if HORDE.subclasses_to_classes[f2] then
                 f2 = HORDE.subclasses_to_classes[f2]
-            end
+            end]]--
 
             if f2 then
                 HORDE:SendSavedPerkChoices(f2)


### PR DESCRIPTION
So, remember this bug, when subclass perk choices get reset, and you have to manually click on it? Apparently it's not just subclass issue, but it's much more noticeable because of other problems. Basically, when you switch class mid-game your perk choices get reset, but fix themselves on next wave. It happens because net.Receive("Horde_PerkChoice") in sv_perk happens after applying perks, so perk choices are there, but they will only apply next Horde_ApplyPerksForClass() (usually at the end of a wave).
Also HORDE:SendSavedPerkChoices() doesn't get call when changing subclasses.
Also code in sh_class, that i wasn't able to understand, makes it so on player init it only sends perk choices of parent class.
Also line 159 in cl_description was calling Horde_SetSubclass, but it already gets called in sv_economy net.Recieve("Horde_ChangeClass"). Nothing bad happens though, except for double notification about subclass changing.
Debugging this was hell.