### PR TITLE
Fix for Ionization causing all damage to become direct damage

### DIFF
--- a/gamemode/perks/cremator/cremator_ionization.lua
+++ b/gamemode/perks/cremator/cremator_ionization.lua
@@ -16,5 +16,7 @@ end
 
 PERK.Hooks.Horde_OnPlayerDamagePost = function (ply, npc, bonus, hitgroup, dmginfo)
     if not ply:Horde_GetPerk("cremator_ionization")  then return end
+	if HORDE:IsFireDamage(dmginfo) then
     dmginfo:SetDamageType(DMG_DIRECT)
+	end
 end


### PR DESCRIPTION
Cremator's Ionization perk currently causes all damage dealt to become direct damage despite the perk's description stating that it only affects fire damage. This fix adds a check to make sure that the damage type is fire damage.