### PR TITLE
Fix for Butane Can not dealing damage properly

### DIFF
--- a/gamemode/gadgets/gadget_butane_can.lua
+++ b/gamemode/gadgets/gadget_butane_can.lua
@@ -30,7 +30,7 @@ end
 
 GADGET.Hooks.Horde_OnPlayerDamage = function (ply, npc, bonus, hitgroup, dmginfo)
     if ply:Horde_GetGadget() ~= "gadget_butane_can" then return end
-    if dmginfo:GetInflictor():GetModel() == "models/props_c17/olidrum001_explosive.mdl" then
+    if dmginfo:GetInflictor():GetModel() == "models/props_c17/oildrum001_explosive.mdl" then
         bonus.increase = bonus.increase + 10.0
         dmginfo:SetDamageType(DMG_BURN)
     end


### PR DESCRIPTION
Currently, Butane Can does not function properly due to a typo in the code that prevents it from registering the proper model to seek for when dealing damage. This fix causes the model path to be proper.