### PR TITLE
Fix for Breathing Technique to gain Break Immunity

### DIFF
--- a/gamemode/perks/berserker/berserker_breathing_technique.lua
+++ b/gamemode/perks/berserker/berserker_breathing_technique.lua
@@ -1,5 +1,5 @@
 PERK.PrintName = "Breathing Technique"
-PERK.Description = "Regenerate {1} health per second.\nImmune to Poison damage."
+PERK.Description = "Regenerate {1} health per second.\nImmune to Poison damage and Break."
 PERK.Icon = "materials/perks/breathing_technique.png"
 PERK.Params = {
     [1] = {value = 0.02, percent = true},
@@ -22,5 +22,12 @@ PERK.Hooks.Horde_OnPlayerDamageTaken = function (ply, dmginfo, bonus)
     if not ply:Horde_GetPerk("berserker_breathing_technique") then return end
     if HORDE:IsPoisonDamage(dmginfo) then
         bonus.resistance = bonus.resistance + 1.0
+    end
+end
+
+PERK.Hooks.Horde_OnPlayerDebuffApply = function (ply, debuff, bonus)
+    if ply:Horde_GetPerk("berserker_breathing_technique") and debuff == HORDE.Status_Break then
+        bonus.apply = 0
+        return true
     end
 end


### PR DESCRIPTION
Although Breathing Technique's poison damage immunity makes you immune to most methods of gaining Break, it does not prevent gaining Break if it were directly applied. This fix gives it proper immunity to Break, along with some clarification in the description of the perk.