### PR TITLE
Fix for relationship flags of Matriarch Womb's special headcrab

### DIFF
--- a/entities/entities/npc_vj_horde_headcrab/init.lua
+++ b/entities/entities/npc_vj_horde_headcrab/init.lua
@@ -2,7 +2,7 @@ AddCSLuaFile("shared.lua")
 include('shared.lua')
 
 ENT.Model = {"models/headcrabclassic.mdl"} -- The game will pick a random model from the table when the SNPC is spawned | Add as many as you want
-ENT.VJ_NPC_Class = {"CLASS_PLAYER_ALLY"}
+ENT.VJ_NPC_Class = {"CLASS_PLAYER_ALLY", "CLASS_COMBINE"}
 ENT.TurningSpeed = 60 -- How fast it can turn
 ENT.StartHealth = 1
 ENT.LeapDistance = 100 -- The distance of the leap, for example if it is set to 500, when the SNPC is 500 Unit away, it will jump
@@ -11,6 +11,7 @@ ENT.LeapAttackVelocityForward = 100 -- How much forward force should it apply?
 ENT.LeapAttackVelocityUp = 150 -- How much upward force should it apply?
 ENT.NextLeapAttackTime = 5 -- How much time until it can use a leap attack?
 ENT.NextAnyAttackTime_Leap = 1 -- How much time until it can use any attack again? | Counted in Seconds
+ENT.PlayerFriendly = true -- Makes the SNPC friendly to the player and HL2 Resistance
 ---------------------------------------------------------------------------------------------------------------------------------------------
 ENT.HasMeleeAttack = false
 ENT.MeleeAttackDamage = 1
@@ -23,7 +24,7 @@ ENT.GeneralSoundPitch2 = 120
 ---------------------------------------------------------------------------------------------------------------------------------------------
 function ENT:CustomOnInitialize()
 	self:SetCollisionBounds(Vector(20, 20, 20), Vector(-20, -20, 0))
-    self.VJ_NPC_Class = {"CLASS_PLAYER_ALLY"}
+    self.VJ_NPC_Class = {"CLASS_PLAYER_ALLY", "CLASS_COMBINE"}
 	self:AddRelationship("player D_LI 99")
     self:AddRelationship("ally D_LI 99")
 	if HORDE.items["npc_vj_horde_vortigaunt"] then
@@ -39,6 +40,7 @@ function ENT:CustomOnInitialize()
         self:AddRelationship("npc_manhack D_LI 99")
     end
     self:AddRelationship("npc_vj_horde_spectre D_LI 99")
+	self:AddRelationship("npc_vj_horde_antlion D_LI 99")
 end
 
 VJ.AddNPC("Headcrab","npc_vj_horde_headcrab", "Horde")


### PR DESCRIPTION
The headcrab spawned by Matriarch Womb currently has a bug where the relationship flags are not set properly for it, causing player minions to be able to target it, which does not end up doing anything since minions cannot damage each other. This fix sets up the relationship flags properly.