### PR TITLE
Money dropping improvements

### DIFF
--- a/entities/entities/horde_money/init.lua
+++ b/entities/entities/horde_money/init.lua
@@ -24,7 +24,7 @@ function ENT:Initialize()
     self.Removing = false
     self:PhysWake()
 
-    timer.Simple(5, function ()
+    timer.Simple(10, function ()
         if self:IsValid() then
             self:Remove()
         end

--- a/gamemode/sv_commands.lua
+++ b/gamemode/sv_commands.lua
@@ -204,7 +204,7 @@ hook.Add("PlayerSay", "Horde_Commands", function(ply, input, public)
         ply:PrintMessage(HUD_PRINTTALK, "'!ready' - Get ready")
         ply:PrintMessage(HUD_PRINTTALK, "'!shop' - Open shop")
         ply:PrintMessage(HUD_PRINTTALK, "'!drop' - Drop weapon")
-        ply:PrintMessage(HUD_PRINTTALK, "'!throwmoney' - Drop 50$")
+        ply:PrintMessage(HUD_PRINTTALK, "'!throwmoney <amount>' - Drop money")
         ply:PrintMessage(HUD_PRINTTALK, "'!rtv' -Initiate a map change vote")
     elseif text[1] == "!start" then
         Start(ply)

--- a/gamemode/sv_commands.lua
+++ b/gamemode/sv_commands.lua
@@ -194,39 +194,44 @@ end
 
 hook.Add("PlayerSay", "Horde_Commands", function(ply, input, public)
     if not ply:IsValid() then return end
-    local text = string.lower(input) -- Make the chat message entirely lowercase
-    if text == "!help" then
+    local text = {}
+	
+    for str in string.gmatch(string.lower(input), "([^".."%s".."]+)") do -- splits and lowercases the input string
+       table.insert(text, str)
+    end
+	
+    if text[1] == "!help" then
         ply:PrintMessage(HUD_PRINTTALK, "'!ready' - Get ready")
         ply:PrintMessage(HUD_PRINTTALK, "'!shop' - Open shop")
         ply:PrintMessage(HUD_PRINTTALK, "'!drop' - Drop weapon")
         ply:PrintMessage(HUD_PRINTTALK, "'!throwmoney' - Drop 50$")
         ply:PrintMessage(HUD_PRINTTALK, "'!rtv' -Initiate a map change vote")
-    elseif text == "!start" then
+    elseif text[1] == "!start" then
         Start(ply)
-    elseif text == "!ready" then
+    elseif text[1] == "!ready" then
         Ready(ply)
-    elseif text == "!end" then
+    elseif text[1] == "!end" then
         End(ply)
-    elseif text == "!shop" then
+    elseif text[1] == "!shop" then
         Shop(ply)
-    elseif text == "!itemconfig" then
+    elseif text[1] == "!itemconfig" then
         ItemConfig(ply)
-    elseif text == "!enemyconfig" then
+    elseif text[1] == "!enemyconfig" then
         EnemyConfig(ply)
-    elseif text == "!classconfig" then
+    elseif text[1] == "!classconfig" then
         ClassConfig(ply)
-    elseif text == "!mapconfig" then
+    elseif text[1] == "!mapconfig" then
         MapConfig(ply)
-    elseif text == "!drop" then
+    elseif text[1] == "!drop" then
         if ply:GetActiveWeapon() and ply:GetActiveWeapon():IsValid() and ply:GetActiveWeapon().Base == "horde_spell_weapon_base" then
             return
         end
         ply:DropWeapon()
-    elseif text == "!throwmoney" then
-        ply:Horde_DropMoney()
-    elseif text == "!rtv" then
+    elseif text[1] == "!throwmoney" then
+        ply:Horde_DropMoney(text[2])
+    elseif text[1] == "!rtv" then
         HORDE.VoteChangeMap(ply)
-    elseif text == "!stats" then
+    elseif text[1] == "!stats" then
         StatsMenu(ply)
     --[[elseif text == "!sync_to_local" then
         HORDE:SyncToLocal(ply)

--- a/gamemode/sv_economy.lua
+++ b/gamemode/sv_economy.lua
@@ -195,7 +195,8 @@ end
 
 function plymeta:Horde_DropMoney(amount)
 	amount = tonumber(amount)
-	if not amount then amount = 50 end 
+	amount = floor(amount) -- ensure that unholy amounts of money are not being dropped
+	if not amount or amount < 50 then amount = 50 end 
     if self:Horde_GetMoney() >= amount and self:Alive() then
         local res = hook.Run("Horde_PlayerDropMoney", self)
         if res then

--- a/gamemode/sv_economy.lua
+++ b/gamemode/sv_economy.lua
@@ -1,5 +1,5 @@
 concommand.Add("horde_drop_money", function (ply, cmd, args)
-    ply:Horde_DropMoney()
+    ply:Horde_DropMoney(args[1])
 end)
 
 concommand.Add("horde_drop_weapon", function (ply, cmd, args)
@@ -193,14 +193,16 @@ function plymeta:Horde_GetDropEntities()
     return self.Horde_drop_entities
 end
 
-function plymeta:Horde_DropMoney()
-    if self:Horde_GetMoney() >= 50 and self:Alive() then
+function plymeta:Horde_DropMoney(amount)
+	amount = tonumber(amount)
+	if not amount then amount = 50 end 
+    if self:Horde_GetMoney() >= amount and self:Alive() then
         local res = hook.Run("Horde_PlayerDropMoney", self)
         if res then
             self:Horde_SyncEconomy()
             return
         end
-        self:Horde_AddMoney(-50)
+        self:Horde_AddMoney(-amount)
         local money = ents.Create("horde_money")
         local pos = self:GetPos()
         local dir = (self:GetEyeTrace().HitPos - pos)
@@ -208,11 +210,13 @@ function plymeta:Horde_DropMoney()
         local drop_pos = pos + dir * 50
         drop_pos.z = pos.z + 15
         money:SetPos(drop_pos)
-        money:DropToFloor()
+        --money:DropToFloor() -- DropToFloor() causes money to fall through dispacements and slopes
         money:Spawn()
+		money:SetMoney(amount)
         self:Horde_SyncEconomy()
     end
 end
+
 
 function plymeta:Horde_GetMaxWeight()
     return self.Horde_max_weight


### PR DESCRIPTION
Allows you to drop more that 50$ at once with !throwmoney or horde_drop_money.
Surprised this wasn't done before, considering that horde_money already has the necessary function.
Shouldn't cause any conflicts with existing stuff.
Also now that dropping huge amounts of cash is much easier, increases money lifetime to 10 seconds, because you don't want to lose billions because your friend is too slow.
Also money no longer drops to the floor, as this causes issues with displacements and slopes.
As a bonus, allows chat commands to have args, which might come handy in the future.