### PR TITLE
Samurai fixes

### DIFF
--- a/gamemode/perks/samurai/samurai_demon_strike.lua
+++ b/gamemode/perks/samurai/samurai_demon_strike.lua
@@ -19,7 +19,7 @@ end
 
 PERK.Hooks.Horde_OnPlayerDamage = function (ply, npc, bonus, hitgroup, dmginfo)
     if not ply:Horde_GetPerk("samurai_demon_strike") then return end
-    if HORDE:IsMeleeDamage(dmginfo) then
+    if HORDE:IsMeleeDamage(dmginfo) and npc:Horde_HasDebuff(HORDE.Status_Bleeding) then
         bonus.increase = bonus.increase + 0.3
     end
 end

--- a/gamemode/perks/samurai/samurai_exsanguinate.lua
+++ b/gamemode/perks/samurai/samurai_exsanguinate.lua
@@ -1,7 +1,7 @@
 PERK.PrintName = "Exsanguinate"
 PERK.Description =
 [[20% increased Bleeding buildup.
-Recover health neary Bleeding enemies.
+Recover 5 health per second while near an enemy with Bleeding.
 Immune to Bleeding.]]
 PERK.Icon = "materials/perks/samurai/exsanguinate.png"
 PERK.Params = {
@@ -19,7 +19,7 @@ PERK.Hooks.Horde_OnSetPerk = function(ply, perk)
     if SERVER and perk == "samurai_exsanguinate" then
       local id = ply:SteamID()
       timer.Create("Horde_Exsanguinate" .. id, 1, 0, function ()
-          if not ply:IsValid() or not ply:Alive() or not ply:Horde_GetPerk("samurai_exsanguinate") then timer.Remove("Horde_Superfluidity" .. id) return end
+          if not ply:IsValid() or not ply:Alive() or not ply:Horde_GetPerk("samurai_exsanguinate") then timer.Remove("Horde_Exsanguinate" .. id) return end
           for _, ent in pairs(ents.FindInSphere(ply:GetPos(), 300)) do
               if ent:Horde_HasDebuff(HORDE.Status_Bleeding) then
                 HORDE:SelfHeal(ply, 5)


### PR DESCRIPTION
Samurai's Demon Strike currently does not have a check to see if the target has the bleeding debuff for the melee damage increase, and this adds a check to make sure it does.

Exsanguinate currently has a bug where it does not properly remove the timer that handles the effect, and this fixes it.

Additionally, I have included an update to Exsanguinate's description to fix the typo with it and make it clearer as to how the healing effect works.