### PR TITLE
Direct Hit + ULPA Filter display fixes

### DIFF
--- a/gamemode/gadgets/gadget_ulpa_filter.lua
+++ b/gamemode/gadgets/gadget_ulpa_filter.lua
@@ -8,7 +8,7 @@ GADGET.Cooldown = 0
 GADGET.Active = false
 GADGET.Params = {
     [1] = {value = 0.2, percent = true},
-    [2] = {value = 0.75, percent = true},
+    [2] = {value = 0.25, percent = true},
 }
 GADGET.Hooks = {}
 

--- a/gamemode/perks/demolition/demolition_direct_hit.lua
+++ b/gamemode/perks/demolition/demolition_direct_hit.lua
@@ -1,6 +1,6 @@
 PERK.PrintName = "Direct Hit"
 PERK.Description = [[{1} increased Blast damage against enemies close to explosions.
-{2} incraesed Blunt damage.]]
+{2} increased Blunt damage.]]
 PERK.Icon = "materials/perks/direct_hit.png"
 PERK.Params = {
     [1] = {value = 0.2, percent = true},


### PR DESCRIPTION
With the 1.2.1 update, some of the new additions have typos in their description or display the incorrect amount. This fixes it.