### PR TITLE
Flash crash fix

### DIFF
--- a/gamemode/gadgets/gadget_flash.lua
+++ b/gamemode/gadgets/gadget_flash.lua
@@ -23,7 +23,7 @@ GADGET.Hooks.Horde_UseActiveGadget = function (ply)
         ply.Horde_In_Flash = nil
         ply.Horde_Invincible = nil
         ply:SetLocalVelocity(Vector(0,0,0))
-        ply:Horde_RemovePhasing()
+        --ply:Horde_RemovePhasing() -- sv_phasing.lua already does that
     end)
     timer.Simple(0, function() ply:SetLocalVelocity(vel) end)
 end

--- a/gamemode/status/buff/sv_phasing.lua
+++ b/gamemode/status/buff/sv_phasing.lua
@@ -10,8 +10,8 @@ function plymeta:Horde_AddPhasing(duration, callback)
 
     if self.Horde_Phasing then return end
 
-    self:CollisionRulesChanged()
     self.Horde_Phasing = true
+    self:CollisionRulesChanged()
     --[[net.Start("Horde_SyncStatus")
         net.WriteUInt(HORDE.Status_Phasing, 8)
         net.WriteUInt(1, 8)


### PR DESCRIPTION
A fix for who-knows-how-many-years old crash related to flash.
The reason for the crash was, as gmod wiki puts it: "Failure to use this function (Entity:CollisionRulesChanged()) correctly will result in a crash of the physics engine."
Also, it removes an extra remove phasing function in callback().

Steps to recreate the original crash:
1) Spawn a lot of zombies
2) Get close and look directly down
3) Use flash (if you press T fast enough, you can use it twice actually. Makes crashing more consistent)
4) Total crash of physics engine and vphysics.dll

The crash no longer occured during my testing after these changes.