### PR TITLE
minor reactive armor fixes

### DIFF
--- a/gamemode/status/buff/sv_reactive_armor.lua
+++ b/gamemode/status/buff/sv_reactive_armor.lua
@@ -34,7 +34,7 @@ end
 
 hook.Add("Horde_OnPlayerDamageTaken", "Horde_ReactiveArmorDamage", function (ply, dmginfo, bonus, silent)
     if silent then return end
-    if ply:IsValid() and ply:Horde_GetReactiveArmorEnabled() and ply:Horde_GetReactiveArmor() == 1 and dmginfo:GetAttacker() ~= ply and dmginfo:GetDamage() >= 25 then
+    if ply:IsValid() and ply:Horde_GetReactiveArmorEnabled() and ply:Horde_GetReactiveArmor() == 1 and dmginfo:GetAttacker() ~= ply and dmginfo:GetDamage() >= 25 and ply:Health() < dmginfo:GetDamage() then
         bonus.resistance = 1
         local dmg = DamageInfo()
         dmg:SetAttacker(ply)

--- a/gamemode/status/buff/sv_reactive_armor.lua
+++ b/gamemode/status/buff/sv_reactive_armor.lua
@@ -34,7 +34,7 @@ end
 
 hook.Add("Horde_OnPlayerDamageTaken", "Horde_ReactiveArmorDamage", function (ply, dmginfo, bonus, silent)
     if silent then return end
-    if ply:IsValid() and ply:Horde_GetReactiveArmorEnabled() and ply:Horde_GetReactiveArmor() == 1 and dmginfo:GetAttacker() ~= ply then
+    if ply:IsValid() and ply:Horde_GetReactiveArmorEnabled() and ply:Horde_GetReactiveArmor() == 1 and dmginfo:GetAttacker() ~= ply and dmginfo:GetDamage() >= 25 then
         bonus.resistance = 1
         local dmg = DamageInfo()
         dmg:SetAttacker(ply)
@@ -46,7 +46,7 @@ hook.Add("Horde_OnPlayerDamageTaken", "Horde_ReactiveArmorDamage", function (ply
         effectdata:SetOrigin( ply:GetPos() )
         util.Effect("Explosion", effectdata)
         ply:Horde_RemoveReactiveArmor()
-        ply:SetArmor(ply:Armor() * 0.75)
+        ply:SetArmor(math.max(0, ply:Armor() - ply:GetMaxArmor() * 0.25))
         timer.Remove("Horde_RestockReactiveArmor" .. ply:SteamID())
         timer.Create("Horde_RestockReactiveArmor" .. ply:SteamID(), 6, 1, function ()
             ply:Horde_AddReactiveArmor()


### PR DESCRIPTION
Adds a check that makes sure that received damage is >= 25, like the perk description says.
Adds a check that makes it activate only if critical damage is received (if i understand correctly what 'critical' means)
Changes line 49 to actually reduce your armor by 25% of max armor, like the perk description says.