### PR TITLE
Omnislash QOL cooldown change

### DIFF
--- a/gamemode/gadgets/gadget_omnislash.lua
+++ b/gamemode/gadgets/gadget_omnislash.lua
@@ -46,7 +46,14 @@ GADGET.Hooks.Horde_UseActiveGadget = function (ply)
     })
     
     local ent = tr.Entity
+	
+	if not ent:IsValid() then
+	ply:EmitSound("items/suitchargeno1.wav")
+	ply:Horde_SetGadgetCooldown(1)
+	return end
+	
     if HORDE:IsEnemy(ent) then
+		ply:Horde_SetGadgetCooldown(15)
         local ply_pos = ply:GetPos()
         local ply_angles = ply:GetAngles()
         ply:Spectate(OBS_MODE_CHASE)


### PR DESCRIPTION
Omnislash currently does not have a check to make sure that the target is valid when activated, meaning that if you don't get a target, you will have to wait out the 15 second cooldown. This adds a check to set the cooldown to 1 second if you don't get a successful target, along with setting the cooldown back to 15 seconds upon getting a successful target.