### PR TITLE
Fix CL race condition error and resource.Add content

### DIFF
--- a/entities/entities/npc_vj_horde_blight/init.lua
+++ b/entities/entities/npc_vj_horde_blight/init.lua
@@ -47,10 +47,6 @@ function ENT:CustomOnInitialize()
 end
 
 function ENT:CustomOnDeath_BeforeCorpseSpawned(dmginfo, hitgroup)
-    if hitgroup == HITGROUP_HEAD then
-        self.HasDeathRagdoll = true
-        return
-    end
     local e = EffectData()
         e:SetOrigin(self:GetPos())
     util.Effect("blight_explosion", e, true, true)

--- a/entities/entities/npc_vj_horde_exploder/init.lua
+++ b/entities/entities/npc_vj_horde_exploder/init.lua
@@ -47,10 +47,6 @@ function ENT:CustomOnInitialize()
 end
 
 function ENT:CustomOnDeath_BeforeCorpseSpawned(dmginfo, hitgroup)
-    if hitgroup == HITGROUP_HEAD then
-        self.HasDeathRagdoll = true
-        return
-    end
     local e = EffectData()
         e:SetOrigin(self:GetPos())
     util.Effect("exploder_explosion", e, true, true)

--- a/gamemode/cl_achievement.lua
+++ b/gamemode/cl_achievement.lua
@@ -7,7 +7,8 @@ local path
 local strm
 
 hook.Add("InitPostEntity", "Horde_PlayerInitAchievements", function()
-    EXPECTED_HEADER = util.SHA256("HordeAchievements" .. LocalPlayer():SteamID())
+    MySelf = LocalPlayer()
+    EXPECTED_HEADER = util.SHA256("HordeAchievements" .. MySelf:SteamID())
     HORDE:CheckUpdate()
 end)
 

--- a/gamemode/cl_achievement.lua
+++ b/gamemode/cl_achievement.lua
@@ -7,7 +7,7 @@ local path
 local strm
 
 hook.Add("InitPostEntity", "Horde_PlayerInitAchievements", function()
-    EXPECTED_HEADER = util.SHA256("HordeAchievements" .. MySelf:SteamID())
+    EXPECTED_HEADER = util.SHA256("HordeAchievements" .. LocalPlayer():SteamID())
     HORDE:CheckUpdate()
 end)
 

--- a/gamemode/init.lua
+++ b/gamemode/init.lua
@@ -1,3 +1,5 @@
+resource.AddWorkshop( "2401598805" )
+
 AddCSLuaFile("cl_init.lua")
 AddCSLuaFile("shared.lua")
 AddCSLuaFile("sh_particles.lua")


### PR DESCRIPTION
Fixes an error that can happen when `MySelf` doesn't exist yet as the other `InitPostEntity` didn't run yet
Adds a `resource.AddWorkshop` for so content is automatically served