### PR TITLE
Xen Destroyer Unit CustomOnTakeDamage_BeforeDamage fix

### DIFF
--- a/entities/entities/npc_vj_horde_xen_destroyer_unit/init.lua
+++ b/entities/entities/npc_vj_horde_xen_destroyer_unit/init.lua
@@ -124,8 +124,11 @@ end
 ENT.Critical = nil
 
 function ENT:CustomOnTakeDamage_BeforeDamage(dmginfo, hitgroup)
-	if HORDE:IsLightningDamage(dmginfo) or HORDE:IsBlastDamage(dmginfo) then
-		dmginfo:ScaleDamage(1.25)
+    if HORDE:IsLightningDamage(dmginfo) or HORDE:IsBlastDamage(dmginfo) then
+        dmginfo:ScaleDamage(1.25)
+    end
+    if HORDE:IsPhysicalDamage(dmginfo) then
+        dmginfo:ScaleDamage(0.75)
     end
 end
 
@@ -342,14 +345,6 @@ function ENT:MultipleRangeAttacks()
 	else
 		self.Garg_AttackType = -1
 		self.Garg_AbleToFlame = false
-	end
-end
-
-function ENT:CustomOnTakeDamage_BeforeDamage(dmginfo, hitgroup)
-	if HORDE:IsPhysicalDamage(dmginfo) then
-		dmginfo:ScaleDamage(0.75)
-	elseif HORDE:IsBlastDamage(dmginfo) then
-		dmginfo:ScaleDamage(1.25)
 	end
 end
 


### PR DESCRIPTION
Fixes the same function being called twice in the code that causes the damage check to not work properly.