### PR TITLE
Flash = Dab

### DIFF
--- a/gamemode/gadgets/gadget_flash.lua
+++ b/gamemode/gadgets/gadget_flash.lua
@@ -1,13 +1,23 @@
 GADGET.PrintName = "Flash"
-GADGET.Description = [[Dashes forward, dealing 100 Slashing damage to all enemies on the path.
-Provides a short invincibility frame.
-Provides Phasing.]]
+GADGET.Description = [[Dash forward dealing slashing damage to all enemies in your path.
+
+Active Gadget:
+Deals {1} slashing damage.
+Invulnerable to all damage for {2} second during the dash.
+You have Phasing for {3} second during the dash.
+{4} reduced fall damage taken until you land on the ground.
+{5} chance to send you and your allies straight to the shadow realm.]]
+
 GADGET.Icon = "items/gadgets/flash.png"
 GADGET.Duration = 0
 GADGET.Cooldown = 10
 GADGET.Active = true
 GADGET.Params = {
     [1] = {value = 100},
+	[2] = {value = 0.25},
+	[3] = {value = 0.25},
+	[4] = {value = 0.9, percent = true},
+	[5] = {value = 0.05, percent = true},
 }
 GADGET.Hooks = {}
 
@@ -19,6 +29,7 @@ GADGET.Hooks.Horde_UseActiveGadget = function (ply)
     local vel = dir * 8000
     ply.Horde_In_Flash = true
     ply.Horde_Invincible = true
+	ply.Flash_Fall_Damage_Prevention = true
     ply:Horde_AddPhasing(0.25, function ()
         ply.Horde_In_Flash = nil
         ply.Horde_Invincible = nil
@@ -29,10 +40,10 @@ GADGET.Hooks.Horde_UseActiveGadget = function (ply)
 end
 
 GADGET.Hooks.Horde_OnPhasingCollide = function (ply, npc)
-    local dmg = DamageInfo()
-    dmg:SetDamage(100)
-    dmg:SetDamageType(DMG_SLASH)
     if ply.Horde_In_Flash and not npc.Horde_Taken_Flash_DMG then
+		local dmg = DamageInfo()
+		dmg:SetDamage(100)
+		dmg:SetDamageType(DMG_SLASH)
         dmg:SetInflictor(ply)
         dmg:SetAttacker(ply)
         dmg:SetDamagePosition(npc:GetPos())
@@ -50,4 +61,18 @@ GADGET.Hooks.Horde_OnPlayerDamageTaken = function (ply, dmginfo, bonus)
     if not ply.Horde_Invincible  then return end
     dmginfo:SetDamage(0)
     return true
+end
+
+GADGET.Hooks.Horde_GetFallDamage = function(ply, speed, bonus)
+    if ply:Horde_GetGadget() ~= "gadget_flash" then return end
+	if not ply.Flash_Fall_Damage_Prevention then return end
+	bonus.less = bonus.less * 0.1
+	ply.Flash_Fall_Damage_Prevention = nil
+end
+
+GADGET.Hooks.PlayerTick = function (ply, mv)
+    if not ply.Flash_Fall_Damage_Prevention or not ply:Alive() then return end
+    if ply:IsOnGround() and not ply.Horde_In_Flash then
+        ply.Flash_Fall_Damage_Prevention = nil
+    end
 end

--- a/gamemode/gadgets/gadget_flash.lua
+++ b/gamemode/gadgets/gadget_flash.lua
@@ -14,10 +14,10 @@ GADGET.Cooldown = 10
 GADGET.Active = true
 GADGET.Params = {
     [1] = {value = 100},
-	[2] = {value = 0.25},
-	[3] = {value = 0.25},
-	[4] = {value = 0.9, percent = true},
-	[5] = {value = 0.05, percent = true},
+    [2] = {value = 0.25},
+    [3] = {value = 0.25},
+    [4] = {value = 0.9, percent = true},
+    [5] = {value = 0.05, percent = true},
 }
 GADGET.Hooks = {}
 
@@ -29,7 +29,7 @@ GADGET.Hooks.Horde_UseActiveGadget = function (ply)
     local vel = dir * 8000
     ply.Horde_In_Flash = true
     ply.Horde_Invincible = true
-	ply.Flash_Fall_Damage_Prevention = true
+    ply.Flash_Fall_Damage_Prevention = true
     ply:Horde_AddPhasing(0.25, function ()
         ply.Horde_In_Flash = nil
         ply.Horde_Invincible = nil
@@ -41,9 +41,9 @@ end
 
 GADGET.Hooks.Horde_OnPhasingCollide = function (ply, npc)
     if ply.Horde_In_Flash and not npc.Horde_Taken_Flash_DMG then
-		local dmg = DamageInfo()
-		dmg:SetDamage(100)
-		dmg:SetDamageType(DMG_SLASH)
+        local dmg = DamageInfo()
+        dmg:SetDamage(100)
+        dmg:SetDamageType(DMG_SLASH)
         dmg:SetInflictor(ply)
         dmg:SetAttacker(ply)
         dmg:SetDamagePosition(npc:GetPos())
@@ -65,9 +65,9 @@ end
 
 GADGET.Hooks.Horde_GetFallDamage = function(ply, speed, bonus)
     if ply:Horde_GetGadget() ~= "gadget_flash" then return end
-	if not ply.Flash_Fall_Damage_Prevention then return end
-	bonus.less = bonus.less * 0.1
-	ply.Flash_Fall_Damage_Prevention = nil
+    if not ply.Flash_Fall_Damage_Prevention then return end
+    bonus.less = bonus.less * 0.1
+    ply.Flash_Fall_Damage_Prevention = nil
 end
 
 GADGET.Hooks.PlayerTick = function (ply, mv)


### PR DESCRIPTION
This fixes Berserker's Flash gadget from erroring out dealing damage to yourself with Flash while you use it on a screaming Screecher. Hopefully it'll also indirectly fix the Flash = crash issue people have.

I also added 90% less fall damage taken for that single fall damage instance to the gadget since I always hear people mald about reeping to fall damage in game.