### PR TITLE
CrystalFire employment and other minor fixes

### DIFF
--- a/entities/entities/arccw_thr_medicgrenade/shared.lua
+++ b/entities/entities/arccw_thr_medicgrenade/shared.lua
@@ -155,7 +155,7 @@ function ENT:Think()
                     dmg:SetDamageType(DMG_NERVEGAS)
                     dmg:SetAttacker(self.Owner)
                     dmg:SetInflictor(self)
-                    dmg:SetDamagePosition(self:GetPos())
+                    dmg:SetDamagePosition(ent:GetPos())
                     ent:TakeDamageInfo(dmg)
                 end
             end

--- a/entities/weapons/weapon_horde_medkit.lua
+++ b/entities/weapons/weapon_horde_medkit.lua
@@ -52,7 +52,7 @@ function SWEP:PrimaryAttack()
 		self.Owner:LagCompensation( true )
 	end
 
-	local tr = util.TraceLine( {
+	local tr = util.TraceHull( {
 		start = self.Owner:GetShootPos(),
 		endpos = self.Owner:GetShootPos() + self.Owner:GetAimVector() * 100,
 		filter = self.Owner
@@ -79,8 +79,8 @@ function SWEP:PrimaryAttack()
 		local medkit_charge_coeff = math.min(1, self:Clip1() / (need / medkit_heal_coeff))
 
 		if ent:Health() >= ent:GetMaxHealth() * (overheal) then
-			ent:EmitSound( DenySound )
-			self:SetNextPrimaryFire( CurTime() + 1 )
+			--ent:EmitSound( DenySound )
+			--self:SetNextPrimaryFire( CurTime() + 1 )
 			return
 		end
 
@@ -125,8 +125,8 @@ function SWEP:SecondaryAttack()
 	local medkit_charge_coeff = math.min(1, self:Clip1() / (need / medkit_heal_coeff))
 
 	if ent:Health() >= ent:GetMaxHealth() * (overheal) then
-		ent:EmitSound(DenySound)
-		self:SetNextSecondaryFire(CurTime() + 1)
+		--ent:EmitSound(DenySound)
+		--self:SetNextSecondaryFire(CurTime() + 1)
 		return
 	end
 

--- a/gamemode/gui/cl_stats.lua
+++ b/gamemode/gui/cl_stats.lua
@@ -258,81 +258,11 @@ function PANEL:Init()
     local update_text_panel = vgui.Create("DPanel", description_panel)
     update_text_panel:SetSize(self:GetParent():GetWide(), 2000)
     update_text_panel:SetVisible(true)
-    local update_text =[[
--- New Framework and Mechanics --
+    local update_text = translate.Get("Game_Dank_Patch_Notes_Info")
 
-
-
--- Perks that have access to their special grenades can now throw their grenades via the quicknade hotkey, “G” by default. Or bind, “horde_use_quick_grenade” to a key/button. You can also disable the default quick grenade key by typing, “"horde_disable_default_quick_grenade_key 1" into the console command.
-
--- Classes and Subclasses now use their own whitelist pools giving them their own unique shop config. If you use your own custom config, you’ll have to set them up again for the subclasses unfortunately.
-
--- Screen effects now use a border hud like system for the base framework (it currently only affects when being healing, as other screen effects will come in future perk updates such as Psycho’s Frenzy Mode screen effect).
-
--- Area of effects such as explosions now use a different formula that allows better control over drop off damage and entity detection (only the framework is here and is meant for future perk updates).
-
--- Items and Gadgets that are automatically stripped (swapping classes) are now instead automatically sold. Gadgets that are purchased while you already have a gadget are now automatically sold (you’ll still need to have the amount of money to buy it but the correct amount of money will be deducted or refunded after purchase).
-
-
-
--- Gameplay Changes --
-
-
--- Ammo boxes will now restore secondary ammo reserves (secondary ammo reserves are ammunition used by equipment like underbarrel grenade launchers).
-
-
-
--- Weapon Changes --
-
-
-
--- Medkit --
-
--- Medkit will now consume up to 20 charges to heal up to 20% of your maximum health and scale accordingly to how much charges are remaining instead of requiring a flat 20 charges to heal a flat 20 amount of health.
-
--- Medkit now works while holding your fire button so you don’t have to spam it.
-
--- Medkit now requires you to have a target in order to heal your target (this means that you can hold your left mouse and flick your mouse and it will instantly heal your target if there is an eligible target.
-
--- Medkit weight is now 0.
-
--- Medkit purchase cost is now 0.
-
--- Every class now starts with a Medkit.
-
--- You cannot drop Medkits (you can still sell it to get rid of it).
-
--- You can no longer use Medkit if you’re at 100% maximum health or at maximum overhealed health (this prevents you from wasting Medkit charges).
-
--- Fixed ammo boxes being eaten due to Medkits never having a full ammo reserve.
-
-
-
--- Grenades --
-
--- Throwing your last grenade never gets rid of your grenade, allowing you to still pick up ammo boxes to refill your grenades. You’ll still have a grenade in your hand while having zero grenades so rip your immersion.
-
--- Grenades now have 2 different throwing modes.
-
--- Primary fire (default - left mouse button) will not cook your grenade and throw your grenade at full velocity while having full bounce effect.
-
--- Secondary fire (default - right mouse) will cook your grenade and throw your grenade at full velocity while having a dampened effect, which will backspin your grenade causing it to cancel most of its momentum.
-
--- Quick grenades will throw grenades at a significantly lower velocity while having a dampened effect. 
-
--- Grenades can no longer be dropped (you can still sell it to get rid of it)
-
--- Maximum special grenade reserve capacity limited to 9 grenades
-
--- Most grenades have had their fuse time set to 2 seconds with the exception of stun grenades which have 1.25 seconds.
-
--- Assault and SpecOps stun grenades no longer flashbangs yourself or others, destroy your ears or other ears, nor deal damage to yourself or enemies.
-
--- Stun grenades now always have full stun buildup power (this means it will always stun the enemy no matter the difficulty as long as their internal stun cooldown is off cooldown).
-]]
     local mt = multlinetext(update_text, update_text_panel:GetWide() - 550, 'Content')
     update_text_panel.Paint = function ()
-        draw.SimpleText("Dank Update 2.0.0", 'LargeTitle', 50, 50, color_white, TEXT_ALIGN_LEFT, TEXT_ALIGN_CENTER)
+        draw.SimpleText(translate.Get("Game_Dank_Patch_Notes"), 'LargeTitle', 50, 50, color_white, TEXT_ALIGN_LEFT, TEXT_ALIGN_CENTER)
         draw.DrawText(mt, 'Content', 100, 150, color_white, TEXT_ALIGN_LEFT, TEXT_ALIGN_CENTER)
     end
 

--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -1679,3 +1679,82 @@ LANGUAGE["Gadget_Desc_gadget_barbeque"] = [[
 Ignited enemies killed by you drop edible gibs.
 Each gib restores 5 health.
 ]]
+
+-- Dank Patch notes
+LANGUAGE["Game_Dank_Patch_Notes"] = [[Dank Update 2.0.0]]
+LANGUAGE["Game_Dank_Patch_Notes_Info"] = [[
+-- New Framework and Mechanics --
+
+
+
+-- Perks that have access to their special grenades can now throw their grenades via the quicknade hotkey, “G” by default. Or bind, “horde_use_quick_grenade” to a key/button. You can also disable the default quick grenade key by typing, “"horde_disable_default_quick_grenade_key 1" into the console command.
+
+-- Classes and Subclasses now use their own whitelist pools giving them their own unique shop config. If you use your own custom config, you’ll have to set them up again for the subclasses unfortunately.
+
+-- Screen effects now use a border hud like system for the base framework (it currently only affects when being healing, as other screen effects will come in future perk updates such as Psycho’s Frenzy Mode screen effect).
+
+-- Area of effects such as explosions now use a different formula that allows better control over drop off damage and entity detection (only the framework is here and is meant for future perk updates).
+
+-- Items and Gadgets that are automatically stripped (swapping classes) are now instead automatically sold. Gadgets that are purchased while you already have a gadget are now automatically sold (you’ll still need to have the amount of money to buy it but the correct amount of money will be deducted or refunded after purchase).
+
+
+
+-- Gameplay Changes --
+
+
+-- Ammo boxes will now restore secondary ammo reserves (secondary ammo reserves are ammunition used by equipment like underbarrel grenade launchers).
+
+
+
+-- Weapon Changes --
+
+
+
+-- Medkit --
+
+-- Medkit will now consume up to 20 charges to heal up to 20% of your maximum health and scale accordingly to how much charges are remaining instead of requiring a flat 20 charges to heal a flat 20 amount of health.
+
+-- Medkit now works while holding your fire button so you don’t have to spam it.
+
+-- Medkit now requires you to have a target in order to heal your target (this means that you can hold your left mouse and flick your mouse and it will instantly heal your target if there is an eligible target.
+
+-- Medkit weight is now 0.
+
+-- Medkit purchase cost is now 0.
+
+-- Every class now starts with a Medkit.
+
+-- You cannot drop Medkits and swapping classes no longer drops it (you can still sell it to get rid of it).
+
+-- Medkit is destroyed upon dropping it.
+
+-- You can no longer use Medkit if you’re at 100% maximum health or at maximum overhealed health (this prevents you from wasting Medkit charges).
+
+-- Fixed ammo boxes being eaten due to Medkits never having a full ammo reserve.
+
+
+
+-- Grenades --
+
+-- Throwing your last grenade never gets rid of your grenade, allowing you to still pick up ammo boxes to refill your grenades. You’ll still have a grenade in your hand while having zero grenades so rip your immersion.
+
+-- Grenades now have 2 different throwing modes.
+
+-- Primary fire (default - left mouse button) will not cook your grenade and throw your grenade at full velocity while having full bounce effect.
+
+-- Secondary fire (default - right mouse) will cook your grenade and throw your grenade at full velocity while having a dampened effect, which will backspin your grenade causing it to cancel most of its momentum.
+
+-- Quick grenades will throw grenades at a significantly lower velocity while having a dampened effect. 
+
+-- Grenades can no longer be dropped (you can still sell it to get rid of it)
+
+-- Grenades are destroyed upon dropping it.
+
+-- Maximum special grenade reserve capacity limited to 9 grenades
+
+-- Most grenades have had their fuse time set to 2 seconds with the exception of stun grenades which have 1.25 seconds.
+
+-- Assault and SpecOps stun grenades no longer flashbangs yourself or others, destroy your ears or other ears, nor deal damage to yourself or enemies.
+
+-- Stun grenades now always have full stun buildup power (this means it will always stun the enemy no matter the difficulty as long as their internal stun cooldown is off cooldown).
+]]

--- a/gamemode/languages/russian.lua
+++ b/gamemode/languages/russian.lua
@@ -3078,3 +3078,7 @@ LANGUAGE["Gadget_Desc_gadget_elixir"] = [[
 Восстанавливает 100% вашего здоровья.
 Удаляет все эффекты статусов.
 ]]
+
+-- Dank Patch notes
+--LANGUAGE["Game_Dank_Patch_Notes"] = [[ Giving CrystalFire employment ]]
+--LANGUAGE["Game_Dank_Patch_Notes_Info"] = [[ Giving CrystalFire employment ]]

--- a/gamemode/perks/artificer/artificer_base.lua
+++ b/gamemode/perks/artificer/artificer_base.lua
@@ -27,6 +27,7 @@ PERK.Hooks.Horde_OnSetPerk = function(ply, perk)
         ply:Horde_UnsetSpellWeapon()
         --ply:StripWeapons()
         for _, wpn in pairs(ply:GetWeapons()) do
+            if wpn:GetClass() == "weapon_horde_medkit" then continue end
             ply:DropWeapon(wpn)
         end
         timer.Simple(0.1, function()

--- a/gamemode/perks/carcass/carcass_base.lua
+++ b/gamemode/perks/carcass/carcass_base.lua
@@ -31,6 +31,7 @@ PERK.Hooks.Horde_OnSetPerk = function(ply, perk)
         if ply:HasWeapon("horde_carcass") == true then return end
         --ply:StripWeapons()
         for _, wpn in pairs(ply:GetWeapons()) do
+            if wpn:GetClass() == "weapon_horde_medkit" then continue end
             ply:DropWeapon(wpn)
         end
         timer.Simple(0.1, function() ply:Give("horde_carcass") end)

--- a/gamemode/perks/hatcher/hatcher_base.lua
+++ b/gamemode/perks/hatcher/hatcher_base.lua
@@ -39,6 +39,7 @@ PERK.Hooks.Horde_OnSetPerk = function(ply, perk)
     if SERVER and perk == "hatcher_base" then
         if ply:HasWeapon("horde_pheropod") == true then return end
         for _, wpn in pairs(ply:GetWeapons()) do
+            if wpn:GetClass() == "weapon_horde_medkit" then continue end
             ply:DropWeapon(wpn)
         end
         timer.Simple(0.1, function() ply:Give("horde_pheropod") end)

--- a/gamemode/perks/necromancer/necromancer_base.lua
+++ b/gamemode/perks/necromancer/necromancer_base.lua
@@ -41,6 +41,7 @@ PERK.Hooks.Horde_OnSetPerk = function(ply, perk)
         ply:Horde_UnsetSpellWeapon()
         --ply:StripWeapons()
         for _, wpn in pairs(ply:GetWeapons()) do
+            if wpn:GetClass() == "weapon_horde_medkit" then continue end
             ply:DropWeapon(wpn)
         end
         timer.Simple(0.1, function()

--- a/gamemode/perks/warlock/warlock_base.lua
+++ b/gamemode/perks/warlock/warlock_base.lua
@@ -34,6 +34,7 @@ PERK.Hooks.Horde_OnSetPerk = function(ply, perk)
         ply:Horde_UnsetSpellWeapon()
         --ply:StripWeapons()
         for _, wpn in pairs(ply:GetWeapons()) do
+            if wpn:GetClass() == "weapon_horde_medkit" then continue end
             ply:DropWeapon(wpn)
         end
         timer.Simple(0.1, function()

--- a/gamemode/sv_economy.lua
+++ b/gamemode/sv_economy.lua
@@ -416,10 +416,6 @@ hook.Add("PlayerDroppedWeapon", "Horde_Economy_Drop", function (ply, wpn)
                 end
             end
         end
-
-    end
-    if ply:Horde_GetClass().name == HORDE.Class_Demolition and class == "weapon_frag" then
-        wpn:Remove()
     end
 end)
 
@@ -850,6 +846,7 @@ net.Receive("Horde_SelectClass", function (len, ply)
     -- Drop all weapons
     ply:Horde_SetClass(class)
     for _, wpn in pairs(ply:GetWeapons()) do
+        if wpn:GetClass() == "weapon_horde_medkit" then continue end
         ply:DropWeapon(wpn)
     end
     ply:Horde_SetSubclass(name, subclass_name)

--- a/gamemode/sv_perk.lua
+++ b/gamemode/sv_perk.lua
@@ -85,13 +85,14 @@ net.Receive("Horde_PerkChoice", function(len, ply)
 
     ply:Horde_SetMaxHealth()
     ply:Horde_SetMaxArmor()
-    if ply:Horde_GetSpellWeapon() then
-        ply:Horde_RecalcAndSetMaxMind()
-    else
-        ply:Horde_SetMaxMind(0)
-        ply:Horde_SetMind(0)
-    end
-    
+    timer.Simple(0.1, function()
+        if ply:Horde_GetSpellWeapon() then
+            ply:Horde_RecalcAndSetMaxMind()
+        else
+            ply:Horde_SetMaxMind(0)
+            ply:Horde_SetMind(0)
+        end
+    end)
 
     if HORDE.current_wave < HORDE:Horde_GetWaveForPerk(level) then return end
 

--- a/patch_notes.txt
+++ b/patch_notes.txt
@@ -43,7 +43,9 @@ Dank Update 2.0.0
 
 -- Every class now starts with a Medkit.
 
--- You cannot drop Medkits (you can still sell it to get rid of it).
+-- You cannot drop Medkits and swapping classes no longer drops it (you can still sell it to get rid of it).
+
+-- Medkit is destroyed upon dropping it.
 
 -- You can no longer use Medkit if you’re at 100% maximum health or at maximum overhealed health (this prevents you from wasting Medkit charges).
 
@@ -64,6 +66,8 @@ Dank Update 2.0.0
 -- Quick grenades will throw grenades at a significantly lower velocity while having a dampened effect. 
 
 -- Grenades can no longer be dropped (you can still sell it to get rid of it)
+
+-- Grenades are destroyed upon dropping it.
 
 -- Maximum special grenade reserve capacity limited to 9 grenades
 


### PR DESCRIPTION
The timer is for in some cases where Mind ui gets shown over Armor ui when swapping subclasses.

Added an extra check so that way when swapping classes you don't drop your Medkit. Also made Medkit more forgiving to use.

Moved the patch notes info to the English localization file so that way we can employ CrystalFire for the next few days through torturous translating slave labor. Even though the patch notes are buried in the F2 menu and nobody will read it, it'll be worth the weight.