### PR TITLE
More Minor Fixes

### DIFF
--- a/entities/weapons/arccw_horde_base_melee.lua
+++ b/entities/weapons/arccw_horde_base_melee.lua
@@ -57,7 +57,8 @@ function SWEP:MeleeAttack(melee2)
     local reach = 32 + self:GetBuff_Add("Add_MeleeRange") + self.MeleeRange
     local dmg = self:GetBuff_Override("Override_MeleeDamage", self.MeleeDamage) or 20
     local dmgtype = self:GetBuff_Override("Override_MeleeDamageType") or self.MeleeDamageType or DMG_CLUB
-
+    local ragdoll_force = owner:GetRight() * math.random(-4912, 4912) + owner:GetForward() * math.random(2048, 9989)
+    
     if melee2 then
         reach = 32 + self:GetBuff_Add("Add_MeleeRange") + self.Melee2Range
         dmg = self:GetBuff_Override("Override_MeleeDamage", self.Melee2Damage) or 20
@@ -117,6 +118,7 @@ function SWEP:MeleeAttack(melee2)
                 dmginfo:SetInflictor(self)
                 dmginfo:SetDamage(dmg)
                 dmginfo:SetDamageType(dmgtype)
+                dmginfo:SetDamageForce(ragdoll_force)
                 dmginfo:SetDamagePosition(preHit:NearestPoint(preTr.HitPos))
             
             if(preTr.HitGroup == 1) then
@@ -146,6 +148,15 @@ function SWEP:MeleeAttack(melee2)
                 self:MyEmitSound(self.MeleeHitSound, 75, 100, 1, CHAN_STATIC)
             end
             hitworldSD = true
+            -- To destroy destructible props
+            local dmginfo = DamageInfo()
+                dmginfo:SetAttacker(owner)
+                dmginfo:SetInflictor(self)
+                dmginfo:SetDamage(dmg)
+                dmginfo:SetDamageType(dmgtype)
+                dmginfo:SetDamageForce(ragdoll_force)
+                dmginfo:SetDamagePosition(preHit:NearestPoint(preTr.HitPos))
+            preHit:DispatchTraceAttack(dmginfo, tr)
         end
     end
     self:MyEmitSound(self.MeleeMissSound, 75, 100, 1, CHAN_STATIC)
@@ -172,6 +183,7 @@ function SWEP:MeleeAttack(melee2)
                     dmginfo:SetInflictor(self)
                     dmginfo:SetDamage(dmg)
                     dmginfo:SetDamageType(dmgtype)
+                    dmginfo:SetDamageForce(ragdoll_force)
                     dmginfo:SetDamagePosition(target:GetPos() + target:OBBCenter())
                 target:TakeDamageInfo(dmginfo)
             end

--- a/gamemode/gadgets/gadget_reinforcements.lua
+++ b/gamemode/gadgets/gadget_reinforcements.lua
@@ -21,7 +21,7 @@ GADGET.Hooks.Horde_UseActiveGadget = function (ply)
     sound.Play("horde/player/overlord/projection.mp3", ply:GetPos(), 100, math.random(80, 120))
     
     ply.Horde_overlord_reinforcements = ents.Create("npc_vj_horde_overlord_projection")
-    ply.Horde_overlord_reinforcements:SetPos(ply:GetPos() + ply:GetRight() * -45)
+    ply.Horde_overlord_reinforcements:SetPos(ply:GetPos() + ply:GetRight() * -45 + ply:GetForward() * 45 + Vector(0, 0, 20))
     ply.Horde_overlord_reinforcements:SetAngles(ply:GetAngles())
     ply.Horde_overlord_reinforcements:SetNWEntity("HordeOwner", ply)
     ply.Horde_overlord_reinforcements:SetOwner(ply)

--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -858,7 +858,7 @@ LANGUAGE["Perk_cremator_incineration"] = [[
 
 -- Default Subclasses
 -- Default Perk Psycho
-LANGUAGE["Perk_Title_Overlord_Tier_1"] = [[Sadism]]
+LANGUAGE["Perk_Title_Psycho_Tier_1"] = [[Sadism]]
 LANGUAGE["Perk_Title_psycho_bloodbath"] = [[Bloodbath]]
 LANGUAGE["Perk_psycho_bloodbath"] = [[
 Adds {1} Base Critical Hit chance.
@@ -870,7 +870,7 @@ LANGUAGE["Perk_psycho_savor"] = [[
 Leech {2} of damage dealt when you land a Melee hit.
 Leech caps at {3} health per hit or {4} health per Critical Hit.]]
 
-LANGUAGE["Perk_Title_Overlord_Tier_2"] = [[Violence]]
+LANGUAGE["Perk_Title_Psycho_Tier_2"] = [[Violence]]
 LANGUAGE["Perk_Title_psycho_ferocity"] = [[Ferocity]]
 LANGUAGE["Perk_psycho_ferocity"] = [[
 Adds {1} Base Critical Hit chance.
@@ -881,7 +881,7 @@ LANGUAGE["Perk_psycho_disembowel"] = [[
 {1} increased Critical Hit damage.
 Melee attacks remove Nemesis mutation from enemies.]]
 
-LANGUAGE["Perk_Title_Overlord_Tier_3"] = [[Fatality]]
+LANGUAGE["Perk_Title_Psycho_Tier_3"] = [[Fatality]]
 LANGUAGE["Perk_Title_psycho_skewering"] = [[Skewering]]
 LANGUAGE["Perk_psycho_skewering"] = [[
 Enemies you hit with headshots are Skewered.
@@ -893,7 +893,7 @@ Brutality adds an additional {1} Base Critical Hit chance.
 Brutality also increases Critical Hit damage by {2}.
 Brutality stacks decay {3} slower.]]
 
-LANGUAGE["Perk_Title_Overlord_Tier_4"] = [[Psychosis]]
+LANGUAGE["Perk_Title_Psycho_Tier_4"] = [[Psychosis]]
 LANGUAGE["Perk_Title_psycho_grudge"] = [[Grudge]]
 LANGUAGE["Perk_psycho_grudge"] = [[
 {1} increased movement speed per {2} health missing, up to {3}.

--- a/gamemode/perks/overlord/overlord_juxtapose.lua
+++ b/gamemode/perks/overlord/overlord_juxtapose.lua
@@ -50,7 +50,7 @@ PERK.Hooks.Horde_UseActivePerk = function(ply)
     sound.Play("horde/player/overlord/projection.mp3", ply:GetPos(), 100, math.random(80, 120))
     
     ply.Horde_overlord_juxtapose = ents.Create("npc_vj_horde_overlord_projection")
-    ply.Horde_overlord_juxtapose:SetPos(ply:GetPos() + ply:GetRight() * 45)
+    ply.Horde_overlord_juxtapose:SetPos(ply:GetPos() + ply:GetRight() * 45 + ply:GetForward() * 45 + Vector(0, 0, 20))
     ply.Horde_overlord_juxtapose:SetAngles(ply:GetAngles())
     ply.Horde_overlord_juxtapose:SetNWEntity("HordeOwner", ply)
     ply.Horde_overlord_juxtapose:SetOwner(ply)


### PR DESCRIPTION
Fixed melee weapons not being able to destroy destructible props.
Made Overlord's Projections spawn slightly above and in front of you to prevent them from sinking into the world.
Fixed language callback for Psycho's title tier.