### PR TITLE
Vortigaunt collision fix

### DIFF
--- a/entities/entities/npc_vj_horde_vortigaunt/init.lua
+++ b/entities/entities/npc_vj_horde_vortigaunt/init.lua
@@ -99,7 +99,7 @@ ENT.DisableDefaultRangeAttackCode = true
 ENT.DisableMakingSelfEnemyToNPCs = true
 ---------------------------------------------------------------------------------------------------------------------------------------------
 function ENT:CustomOnInitialize()
-    self:SetCollisionBounds(Vector(0,0,0), Vector(0,0,0))
+    self:SetCollisionGroup(COLLISION_GROUP_DEBRIS)
 end
 
 function ENT:OnRemove()


### PR DESCRIPTION
Currently, the Vortigaunt minion has an issue where you can't target it properly due to the collision boxes being nullified upon entity creation to achieve the effect of not colliding with anything. This fixes it to achieve the same effect by changing the collision group to COLLISION_GROUP_DEBRIS instead, allowing it to ignore all non-world collision while still having something you can target and also not interfering with any traces.